### PR TITLE
Branch error handling refactor

### DIFF
--- a/BananaGit/BananaGit/Models/GitBranchModel.cs
+++ b/BananaGit/BananaGit/Models/GitBranchModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.IO;
 using BananaGit.Exceptions;
 using BananaGit.Utilities;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -23,14 +24,17 @@ namespace BananaGit.Models
                 if (gitInfo != null)
                 {
                     //Check if saved repository exists
-                    //Check here if file path and url exist, throw error that gets caught by GitInfoViewModel
-                    //If no repos are cloned, display clone repo text
                     if (gitInfo.SavedRepository == null)
                     {
-                        //NoRepoCloned = true;
                         throw new InvalidRepoException("No saved repository after loading!");
                     }
-                    
+
+                    //Check if repo location exists
+                    if (!Directory.Exists(LocalRepoFilePath))
+                    {
+                        throw new RepoLocationException("Local repository file location missing!");
+                    }
+
                     //Check if file path is still valid
                     if (!Repository.IsValid(gitInfo.SavedRepository?.FilePath))
                     {

--- a/BananaGit/BananaGit/Models/GitBranchModel.cs
+++ b/BananaGit/BananaGit/Models/GitBranchModel.cs
@@ -41,7 +41,7 @@ namespace BananaGit.Models
             }
 
             //Check if repo location exists
-            if (!Directory.Exists(LocalRepoFilePath))
+            if (!Directory.Exists(gitInfo.SavedRepository?.FilePath))
             {
                 throw new RepoLocationException("Local repository file location missing!");
             }

--- a/BananaGit/BananaGit/Models/GitBranchModel.cs
+++ b/BananaGit/BananaGit/Models/GitBranchModel.cs
@@ -68,7 +68,7 @@ namespace BananaGit.Models
             {
                 //If file path isn't a valid repo, clear file path
 
-                if (gitInfo?.SavedRepository != null)
+                /*f (gitInfo?.SavedRepository != null)
                 {
                     gitInfo.SavedRepository.FilePath = string.Empty;
                 }
@@ -76,9 +76,9 @@ namespace BananaGit.Models
                 {
                     if (gitInfo != null)
                         gitInfo.SavedRepository = new(string.Empty,string.Empty);
-                }
+                }*/
                 
-                JsonDataManager.SaveUserInfo(gitInfo);
+                //JsonDataManager.SaveUserInfo(gitInfo);
                 throw new GitException("No git repository saved or cloned");
             }
             catch (Exception ex)

--- a/BananaGit/BananaGit/Models/GitBranchModel.cs
+++ b/BananaGit/BananaGit/Models/GitBranchModel.cs
@@ -14,81 +14,64 @@ namespace BananaGit.Models
         public bool IsRemote { get; set; }
         public Branch Branch { get; set; }
 
+        /// <summary>
+        /// Default constructor creates branch from HEAD
+        /// </summary>
+        /// <exception cref="RepoLocationException"> The repository saved no longer exists at that location </exception>
+        /// <exception cref="LoadDataException"> Thrown if the user info is missing or can't be loaded </exception>
+        /// <exception cref="GitException"> 
+        /// An overarching git exception, if thrown something 
+        /// relating to git operations or repositories has gone wrong 
+        /// </exception>
         public GitBranch()
         {
             GitInfoModel? gitInfo = new();
             JsonDataManager.LoadUserInfo(ref gitInfo);
 
-            try
+            if (gitInfo == null)
             {
-                if (gitInfo != null)
-                {
-                    //Check if saved repository exists
-                    if (gitInfo.SavedRepository == null)
-                    {
-                        throw new InvalidRepoException("No saved repository after loading!");
-                    }
-
-                    //Check if repo location exists
-                    if (!Directory.Exists(LocalRepoFilePath))
-                    {
-                        throw new RepoLocationException("Local repository file location missing!");
-                    }
-
-                    //Check if file path is still valid
-                    if (!Repository.IsValid(gitInfo.SavedRepository?.FilePath))
-                    {
-                        throw new InvalidRepoException("Saved file path is an invalid repo");
-                    }
-
-                    //Update info
-                    using var repo = new Repository(gitInfo.SavedRepository?.FilePath);
-                    
-                    var options = new FetchOptions();
-
-                    options.CredentialsProvider = (_url, _user, _cred) => new UsernamePasswordCredentials
-                    {
-                        Username = gitInfo.Username,
-                        Password = gitInfo.PersonalToken
-                    };
-                    
-                    string? branchName = Lib2GitSharpExt.GetDefaultRepoName(gitInfo.SavedRepository?.URL, options);
-
-                    if (branchName == null)
-                    {
-                        throw new InvalidRepoException("Couldn't find default branch name");
-                    }
-                    
-                    Branch = repo.Branches[branchName];
-                    Name = Branch.FriendlyName;
-                    IsRemote = Branch.IsRemote;
-                }
-                else
-                {
-                    throw new NullReferenceException("Couldn't load user info");
-                }
+                throw new LoadDataException("Couldn't load user info");
             }
-            catch (InvalidRepoException ex)
+
+            //Check if saved repository exists
+            if (gitInfo.SavedRepository == null)
             {
-                //If file path isn't a valid repo, clear file path
+                throw new InvalidRepoException("No saved repository after loading!");
+            }
 
-                /*f (gitInfo?.SavedRepository != null)
-                {
-                    gitInfo.SavedRepository.FilePath = string.Empty;
-                }
-                else
-                {
-                    if (gitInfo != null)
-                        gitInfo.SavedRepository = new(string.Empty,string.Empty);
-                }*/
-                
-                //JsonDataManager.SaveUserInfo(gitInfo);
-                throw new GitException("No git repository saved or cloned");
-            }
-            catch (Exception ex)
+            //Check if repo location exists
+            if (!Directory.Exists(LocalRepoFilePath))
             {
-                Trace.WriteLine(ex.Message);
+                throw new RepoLocationException("Local repository file location missing!");
             }
+
+            //Check if file path is still valid
+            if (!Repository.IsValid(gitInfo.SavedRepository?.FilePath))
+            {
+                throw new InvalidRepoException("Saved file path is an invalid repo");
+            }
+
+            //Update info
+            using var repo = new Repository(gitInfo.SavedRepository?.FilePath);
+
+            var options = new FetchOptions();
+
+            options.CredentialsProvider = (_url, _user, _cred) => new UsernamePasswordCredentials
+            {
+                Username = gitInfo.Username,
+                Password = gitInfo.PersonalToken
+            };
+
+            string? branchName = Lib2GitSharpExt.GetDefaultRepoName(gitInfo.SavedRepository?.URL, options);
+
+            if (branchName == null)
+            {
+                throw new InvalidRepoException("Couldn't find default branch name");
+            }
+
+            Branch = repo.Branches[branchName];
+            Name = Branch.FriendlyName;
+            IsRemote = Branch.IsRemote;
         }
         public GitBranch(Branch branch)
         {

--- a/BananaGit/BananaGit/Models/GitInfoModel.cs
+++ b/BananaGit/BananaGit/Models/GitInfoModel.cs
@@ -2,16 +2,10 @@
 {
     public class GitInfoModel
     {
-        public GitInfoModel() 
-        {
-            Username = string.Empty;
-            PersonalToken = string.Empty;
-            SavedRepository = new(string.Empty, string.Empty);
-        }
-        public string? Username { get; set; }
+        public string? Username { get; set; } = string.Empty;
         public string? Email { get; set; }
-        public string? PersonalToken { get; set; }
-        public SaveableRepository? SavedRepository { get; set; }
+        public string? PersonalToken { get; set; } = string.Empty;
+        public SaveableRepository? SavedRepository { get; set; } = new(string.Empty, string.Empty);
     }
     public class SaveableRepository(string path, string url)
     {

--- a/BananaGit/BananaGit/Utilities/DialogService.cs
+++ b/BananaGit/BananaGit/Utilities/DialogService.cs
@@ -25,7 +25,7 @@ namespace BananaGit.Utilities
         /// </summary>
         public void ShowCredentialsDialog()
         {
-            EnterCredentialsView view = new() { DataContext = vm };
+            EnterCredentialsView view = new();
             view.ShowDialog();
         }
 

--- a/BananaGit/BananaGit/Utilities/Lib2GitSharpExt.cs
+++ b/BananaGit/BananaGit/Utilities/Lib2GitSharpExt.cs
@@ -3,6 +3,9 @@ using LibGit2Sharp;
 
 namespace BananaGit.Utilities;
 
+/// <summary>
+/// Helper methods for Lib2GitSharp
+/// </summary>
 public static class Lib2GitSharpExt
 {
     /// <summary>

--- a/BananaGit/BananaGit/Utilities/Lib2GitSharpExt.cs
+++ b/BananaGit/BananaGit/Utilities/Lib2GitSharpExt.cs
@@ -18,7 +18,7 @@ public static class Lib2GitSharpExt
             var remotes = Repository.ListRemoteReferences(repoUrl, options.CredentialsProvider);
             
             //Cache the first instance of /HEAD
-            var headReference = remotes.FirstOrDefault(x => x.CanonicalName.EndsWith("/HEAD"));
+            var headReference = remotes.FirstOrDefault(x => x.CanonicalName == "HEAD");
 
             if (headReference != null)
             {

--- a/BananaGit/BananaGit/ViewModels/GitInfoViewModel.cs
+++ b/BananaGit/BananaGit/ViewModels/GitInfoViewModel.cs
@@ -142,11 +142,10 @@ namespace BananaGit.ViewModels
             }
             catch (GitException ex)
             {
-                githubUserInfo.SavedRepository = null;
                 //Output to debug console
                 OutputError(ex.Message);
                 NoRepoCloned = true;
-                JsonDataManager.SaveUserInfo(githubUserInfo);
+                //JsonDataManager.SaveUserInfo(githubUserInfo);
             }
             catch (Exception ex)
             {
@@ -588,7 +587,7 @@ namespace BananaGit.ViewModels
         /// Opens a windows prompt to select the desired file directory
         /// </summary>
         [RelayCommand]
-        public void ChooseCloneDirectory()
+        private void ChooseCloneDirectory()
         {
             try
             {
@@ -598,10 +597,11 @@ namespace BananaGit.ViewModels
                 }
 
                 //Open file select dialogue
-                OpenFolderDialog dialog = new OpenFolderDialog();
-                dialog.Multiselect = false;
-
-                dialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                OpenFolderDialog dialog = new OpenFolderDialog
+                {
+                    Multiselect = false,
+                    InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)
+                };
 
                 if (dialog.ShowDialog() == true)
                 {
@@ -631,17 +631,17 @@ namespace BananaGit.ViewModels
                             throw new NullReferenceException("Couldn't find any remotes!");
                         }
 
-                        ResetBranches();
-                        UpdateBranches(repo, new());
-
                         //Save to user info
                         githubUserInfo.SavedRepository = new(LocalRepoFilePath, RepoURL);
                         JsonDataManager.SaveUserInfo(githubUserInfo);
-
+                        
                         //Set flags
                         CanClone = true;
                         DirectoryHasFiles = false;
                         NoRepoCloned = false;
+                        
+                        ResetBranches();
+                        UpdateBranches(repo, new GitBranch());
                     }
                 }
             }
@@ -773,8 +773,6 @@ namespace BananaGit.ViewModels
         {
             LocalBranches.Clear();
             RemoteBranches.Clear();
-            CurrentBranch = new();
-            LocalBranches.Add(CurrentBranch);
         }
         #endregion
     }

--- a/BananaGit/BananaGit/ViewModels/GitInfoViewModel.cs
+++ b/BananaGit/BananaGit/ViewModels/GitInfoViewModel.cs
@@ -99,57 +99,25 @@ namespace BananaGit.ViewModels
             {
                 //Create new git branch
                 CurrentBranch = new GitBranch();
-                
-                //Save data missing
-                if (githubUserInfo == null)
-                {
-                    throw new LoadDataException("ERROR: Data couldn't be loaded!");
-                }
 
-                //If no repos are cloned, display clone repo text
-                if (githubUserInfo.SavedRepository == null)
-                {
-                    NoRepoCloned = true;
-                    throw new InvalidRepoException("No saved repository after loading!");
-                }
-                else
-                {
-                    //Check if repo data is empty
-                    if (!Repository.IsValid(githubUserInfo.SavedRepository.FilePath))
-                    {
-                        throw new InvalidRepoException("Saved repository is empty!");
-                    }
+                //Load current repo data if there is an already opened repo
+                LocalRepoFilePath = githubUserInfo.SavedRepository.FilePath;
+                RepoURL = githubUserInfo.SavedRepository.URL;
 
-                    //Load current repo data if there is an already opened repo
-                    LocalRepoFilePath = githubUserInfo.SavedRepository.FilePath;
-                    RepoURL = githubUserInfo.SavedRepository.URL;
-                }
-
-                //Check if repo location exists
-                if (!Directory.Exists(LocalRepoFilePath))
-                {
-                    NoRepoCloned = true;
-                    throw new RepoLocationException("Local repository file location missing!");
-                }
-
-                //Mark that we successfully cloned the repo
+                //Update that we succesfully initialized the repository
                 NoRepoCloned = false;
 
-                //Add main on first run
-                CurrentBranch = new();
-                LocalBranches.Add(CurrentBranch);
                 UpdateBranches(new Repository(LocalRepoFilePath), CurrentBranch);
             }
             catch (GitException ex)
             {
-                //Output to debug console
                 OutputError(ex.Message);
                 NoRepoCloned = true;
-                //JsonDataManager.SaveUserInfo(githubUserInfo);
             }
             catch (Exception ex)
             {
                 OutputError(ex.Message);
+                NoRepoCloned = true;
             }
         }
 
@@ -255,20 +223,26 @@ namespace BananaGit.ViewModels
         {
             try
             {
+                LocalBranches.Add(currentBranch);
+
+                //Set fetch options to prune any old remote branches
                 var fetchOptions = new FetchOptions { Prune = true };
+
+                //Cache first remote
                 var remote = repo.Network.Remotes.FirstOrDefault();
 
-
+                //Prune remote branches
                 if (remote != null)
                 {
                     Commands.Fetch(repo, remote.Name, new string[0], fetchOptions, "");
                 }
                 else
                 {
-                    throw new NullReferenceException("Couldn't retrieve remote!");
+                    throw new NullReferenceException("Couldn't prune remote branches!");
                 }
 
-                Application.Current.Dispatcher.Invoke((Action)(() =>
+                //Update branch data on a seperate thread
+                Application.Current.Dispatcher.Invoke((() =>
                 {
                     //Update branches
                     foreach (var branch in repo.Branches)
@@ -296,6 +270,7 @@ namespace BananaGit.ViewModels
                         LocalBranches.Add(new GitBranch(branch));
                     }
                 }));
+                //Update current branch
                 CurrentBranch = currentBranch;
             }
             catch (Exception ex)


### PR DESCRIPTION
Moved repo creation error checks to the GitBranch model. The model throws errors but doesn't handle them, so when creating a gitbranch from the default constructor, use error handling. Additionally, I created a more robust way of getting the default HEAD branch name (ie, master, main, dev) without getting old branches or closed branches. 