### PR TITLE
Feature: Added message for user to open repository

### DIFF
--- a/BananaGit/BananaGit/Services/GitService.cs
+++ b/BananaGit/BananaGit/Services/GitService.cs
@@ -74,7 +74,7 @@ namespace BananaGit.Services
         /// <returns></returns>
         public bool IsLocalRepositoryOpen()
         {
-            return _gitInfo?.GetPath() != null;
+            return !string.IsNullOrEmpty(_gitInfo?.GetPath());
         }
 
         /// <summary>

--- a/BananaGit/BananaGit/Services/GitService.cs
+++ b/BananaGit/BananaGit/Services/GitService.cs
@@ -69,6 +69,15 @@ namespace BananaGit.Services
         #region Getters
 
         /// <summary>
+        /// Checks whether a local repository is currently open
+        /// </summary>
+        /// <returns></returns>
+        public bool IsLocalRepositoryOpen()
+        {
+            return _gitInfo?.GetPath() != null;
+        }
+
+        /// <summary>
         /// Checks if the current repo has files commited but not pushed
         /// </summary>
         /// <returns>Whether locally commited files have been pushed</returns>

--- a/BananaGit/BananaGit/ValueConverters/BoolVisibilityConverter.cs
+++ b/BananaGit/BananaGit/ValueConverters/BoolVisibilityConverter.cs
@@ -1,0 +1,27 @@
+﻿using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace BananaGit.ValueConverters;
+
+/// <summary>
+/// Sets a UI elements visibility based on whether a bool is true or false
+/// </summary>
+public class BoolVisibilityConverter : MarkupExtension, IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return System.Convert.ToBoolean(value) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return null;
+    }
+
+    public override object? ProvideValue(IServiceProvider serviceProvider)
+    {
+        return this;
+    }
+}

--- a/BananaGit/BananaGit/ViewModels/CommitHistoryViewModel.cs
+++ b/BananaGit/BananaGit/ViewModels/CommitHistoryViewModel.cs
@@ -16,7 +16,7 @@ partial class CommitHistoryViewModel : ObservableObject
 
     [ObservableProperty] private ObservableCollection<GitCommitInfo> _commitHistory = [];
 
-    public bool IsLocalRepositoryOpen => _gitService.IsLocalRepositoryOpen();
+    public bool IsLocalRepositoryOpen => !_gitService.IsLocalRepositoryOpen();
 
     private readonly GitService _gitService;
 

--- a/BananaGit/BananaGit/ViewModels/CommitHistoryViewModel.cs
+++ b/BananaGit/BananaGit/ViewModels/CommitHistoryViewModel.cs
@@ -12,15 +12,15 @@ namespace BananaGit.ViewModels;
 /// </summary>
 partial class CommitHistoryViewModel : ObservableObject
 {
-    [ObservableProperty]
-    private string _repositoryName = string.Empty;
-    
-    [ObservableProperty]
-    private ObservableCollection<GitCommitInfo> _commitHistory = [];
-    
+    [ObservableProperty] private string _repositoryName = string.Empty;
+
+    [ObservableProperty] private ObservableCollection<GitCommitInfo> _commitHistory = [];
+
+    public bool IsLocalRepositoryOpen => _gitService.IsLocalRepositoryOpen();
+
     private readonly GitService _gitService;
-    
-    private int _maxCommitHistoryLength = 30;
+
+    private const int MaxCommitHistoryLength = 30;
 
     public CommitHistoryViewModel(GitService gitService)
     {
@@ -47,7 +47,7 @@ partial class CommitHistoryViewModel : ObservableObject
             _gitService.OutputToConsole(this, new MessageEventArgs(ex.Message));
         }
     }
-    
+
     /// <summary>
     /// Called when the user pulls changes
     /// </summary>
@@ -57,7 +57,7 @@ partial class CommitHistoryViewModel : ObservableObject
     {
         try
         {
-            CommitHistory = new(_gitService.GetCommitHistory(_maxCommitHistoryLength));
+            CommitHistory = new(_gitService.GetCommitHistory(MaxCommitHistoryLength));
         }
         catch (Exception ex)
         {

--- a/BananaGit/BananaGit/Views/CommitHistoryView.xaml
+++ b/BananaGit/BananaGit/Views/CommitHistoryView.xaml
@@ -4,14 +4,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:BananaGit.Views"
+    xmlns:converters="clr-namespace:BananaGit.ValueConverters"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewmodels="clr-namespace:BananaGit.ViewModels"
     d:DataContext="{d:DesignInstance Type=viewmodels:CommitHistoryViewModel}"
     d:DesignHeight="450"
     d:DesignWidth="400"
     Background="{StaticResource BananaLight}"
-    mc:Ignorable="d"
-    >
+    mc:Ignorable="d">
     <Grid>
 
         <Grid.RowDefinitions>
@@ -26,8 +26,14 @@
         <Label
             VerticalAlignment="Stretch"
             Background="{StaticResource BananaAccent}"
-            Content="{Binding RepositoryName}"
-            />
+            Content="{Binding RepositoryName}" />
+
+        <TextBlock Grid.Row="1"
+                   HorizontalAlignment="Center"
+                   Visibility="{Binding IsLocalRepositoryOpen, Converter={converters:BoolVisibilityConverter}}"
+                   VerticalAlignment="Center" FontSize="22" TextWrapping="WrapWithOverflow">
+            Press clone or open in the toolbar to open a new repository.
+        </TextBlock>
 
         <ScrollViewer
             Grid.Row="1"
@@ -35,46 +41,41 @@
             VerticalAlignment="Stretch"
             CanContentScroll="True"
             HorizontalScrollBarVisibility="Auto"
-            VerticalScrollBarVisibility="Auto"
-            >
+            VerticalScrollBarVisibility="Auto">
             <ItemsControl ItemsSource="{Binding CommitHistory}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <Border
                             x:Name="GitHistoryItemBorder"
                             BorderBrush="{StaticResource BananaGradient}"
-                            BorderThickness="0,3,0,0"
-                            >
+                            BorderThickness="0,3,0,0">
                             <StackPanel Orientation="Vertical">
                                 <StackPanel Orientation="Horizontal">
                                     <Image
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
-                                        Style="{StaticResource GitBananaIconStyle}"
-                                        />
+                                        Style="{StaticResource GitBananaIconStyle}" />
                                     <Label
                                         Content="{Binding Message}"
                                         FontSize="12"
                                         FontWeight="Bold"
-                                        Foreground="Black"
-                                        />
+                                        Foreground="Black" />
                                 </StackPanel>
                                 <StackPanel VerticalAlignment="Bottom" Orientation="Horizontal">
                                     <Label
                                         Content="{Binding Author}"
                                         FontSize="12"
-                                        Foreground="Black"
-                                        />
+                                        Foreground="Black" />
                                     <Label
                                         Content="{Binding Date}"
                                         FontSize="12"
-                                        Foreground="Black"
-                                        />
+                                        Foreground="Black" />
                                 </StackPanel>
                             </StackPanel>
                         </Border>
                         <DataTemplate.Triggers>
-                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource PreviousData}}" Value="{x:Null}">
+                            <DataTrigger Binding="{Binding RelativeSource={RelativeSource PreviousData}}"
+                                         Value="{x:Null}">
                                 <Setter TargetName="GitHistoryItemBorder" Property="BorderThickness" Value="0,0,0,0" />
                             </DataTrigger>
                         </DataTemplate.Triggers>


### PR DESCRIPTION
When no local repository is open, the commit history view will be replaced by a message that tells the user how to open a local repository or clone a remote repository. 